### PR TITLE
[FIX] pstats-print2list: Avoid the six package

### DIFF
--- a/pstats_print2list/pstats_print2list.py
+++ b/pstats_print2list/pstats_print2list.py
@@ -5,7 +5,10 @@ from __future__ import print_function
 import os
 import pstats
 import re
-from six import string_types
+try:
+    basestring
+except NameError:
+    basestring = (str, bytes)
 try:
     from StringIO import StringIO
 except ImportError:
@@ -24,7 +27,7 @@ def get_field_list():
 
 
 def is_fname_match(fname, fmatch_list):
-    if isinstance(fmatch_list, string_types):
+    if isinstance(fmatch_list, basestring):
         fmatch_list = [fmatch_list]
     if not fmatch_list:
         return True
@@ -37,7 +40,7 @@ def is_fname_match(fname, fmatch_list):
 def is_exclude(fname, exclude_fnames):
     if exclude_fnames is None:
         exclude_fnames = []
-    if isinstance(exclude_fnames, string_types):
+    if isinstance(exclude_fnames, basestring):
         exclude_fnames = [exclude_fnames]
     for exclude_fname in exclude_fnames:
         if exclude_fname in fname:
@@ -72,7 +75,7 @@ def get_pstats_print2list(fnames, filter_fnames=None, exclude_fnames=None,
         and limited.
     """
 
-    if isinstance(fnames, string_types):
+    if isinstance(fnames, basestring):
         fnames = [fnames]
     fnames_expanded = [
         os.path.expandvars(os.path.expanduser(fname)) for fname in fnames]


### PR DESCRIPTION
Avoid the six package